### PR TITLE
Add Tailwind setup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,10 @@
+import nextJest from 'next/jest.js';
+
+const createJestConfig = nextJest({ dir: './' });
+
+const config = {
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};
+
+export default createJestConfig(config);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -22,6 +23,12 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "@types/jest": "^29",
+    "@testing-library/react": "^14",
+    "@testing-library/jest-dom": "^6",
+    "jest-environment-jsdom": "^29"
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
 
 export default config;

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import Home from './page';
+
+it('renders Deploy now link', () => {
+  render(<Home />);
+  expect(screen.getByRole('link', { name: /deploy now/i })).toBeInTheDocument();
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["jest"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- add default Tailwind config
- configure PostCSS to load Tailwind and Autoprefixer
- add Jest test runner and example test

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*